### PR TITLE
Add electron import

### DIFF
--- a/app/components/App.tsx
+++ b/app/components/App.tsx
@@ -1,10 +1,15 @@
 import { Counter } from "./Counter.js";
+import electron from "electron";
 
 export default function App({ name = "Anonymous" }) {
   return (
     <div style={{ border: "3px red dashed", margin: "1em", padding: "1em" }}>
       <h1>Hello {name}!!</h1>
-      <h3>This is a server component. {Math.random()}</h3>
+      <h3>
+        This is a server component running on Electron v
+        {electron.app.getVersion()}.
+      </h3>
+      <p>{Math.random()}</p>
       <Counter />
     </div>
   );


### PR DESCRIPTION
This doesn't work right now

```
09:29:02 [vite] Error when evaluating SSR module /node_modules/.pnpm/electron@25.3.2/node_modules/electron/index.js:
|- ReferenceError: require is not defined
    at eval (/Users/tom.sherman/code/waku-desktop/node_modules/.pnpm/electron@25.3.2/node_modules/electron/index.js:3:25)
    at instantiateModule (file:///Users/tom.sherman/code/waku-desktop/node_modules/.pnpm/vite@4.4.7/node_modules/vite/dist/node/chunks/dep-3b8eb186.js:55920:15)

Cannot render RSC ReferenceError: require is not defined
    at eval (/Users/tom.sherman/code/waku-desktop/node_modules/.pnpm/electron@25.3.2/node_modules/electron/index.js:3:25)
    at instantiateModule (file:///Users/tom.sherman/code/waku-desktop/node_modules/.pnpm/vite@4.4.7/node_modules/vite/dist/node/chunks/dep-3b8eb186.js:55920:15)
09:29:02 [vite] Error when evaluating SSR module /dist/assets/App-5735b691.js: failed to import "/node_modules/.pnpm/electron@25.3.2/node_modules/electron/index.js"
|- ReferenceError: require is not defined
    at eval (/Users/tom.sherman/code/waku-desktop/node_modules/.pnpm/electron@25.3.2/node_modules/electron/index.js:3:25)
    at instantiateModule (file:///Users/tom.sherman/code/waku-desktop/node_modules/.pnpm/vite@4.4.7/node_modules/vite/dist/node/chunks/dep-3b8eb186.js:55920:15)
```